### PR TITLE
Fixed dependency

### DIFF
--- a/modules/mdown/markdown.go
+++ b/modules/mdown/markdown.go
@@ -13,9 +13,9 @@ import (
 	"strings"
 	"unicode"
 
+	"github.com/gernest/highlight_go"
 	"github.com/microcosm-cc/bluemonday"
 	"github.com/russross/blackfriday"
-	"github.com/shurcooL/go/highlight_go"
 	"github.com/sourcegraph/syntaxhighlight"
 )
 


### PR DESCRIPTION
The package github.com/shurcool/go/highlight_go seems to be out of
version control. Changed the import to use a fork instead.
