### PR TITLE
Refactored to enable online godoc documentation

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -21,7 +21,7 @@ At the new forked repository, there is a a place which has the project URL. Keep
 ### Step 2 Get the original project
 go get the project
 
-	go get -v github.com/gernest/zedlist
+	go get -v github.com/gernest/zedlist/...
 
 ### Step 3 Setup remotes.
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -8,7 +8,7 @@ This is the easiest and recomended to use. All binaries have been signed. We use
 ## Install from source
 This will require a golang SDK  installed in your machine. Then go get the project.
 
-		$ go get github.com/gernest/zedlist
+		$ go get github.com/gernest/cmd/zedlist
 
 This will create the zedlist binary in the $GOPATH/bin directory.
 

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ ifeq "$(origin CONFIG_DBCONN)" "undefined"
 CONFIG_DBCONN=$(DEFAULT_POSTGRES_CONN)
 endif
 all: lint bindata test
-	@go build
+	@go build ./cmd/zedlist
 
 clean:
 	go clean

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-zedlist [![Coverage Status](https://coveralls.io/repos/gernest/zedlist/badge.svg?branch=master&service=github)](https://coveralls.io/github/gernest/zedlist?branch=master) [![Build Status](https://drone.io/github.com/gernest/zedlist/status.png)](https://drone.io/github.com/gernest/zedlist/latest)
+zedlist [![Coverage Status](https://coveralls.io/repos/gernest/zedlist/badge.svg?branch=master&service=github)](https://coveralls.io/github/gernest/zedlist?branch=master) [![Build Status](https://drone.io/github.com/gernest/zedlist/status.png)](https://drone.io/github.com/gernest/zedlist/latest) [![GoDoc](https://godoc.org/github.com/gernest/zedlist?status.svg)](https://godoc.org/github.com/gernest/zedlist)
 ========
 A humble job recruitment service.
 

--- a/zedlist.go
+++ b/zedlist.go
@@ -2,26 +2,5 @@
 // Use of this source code is governed by a MIT-style
 // license that can be found in the LICENSE file.
 
-package main
-
-import (
-	"os"
-
-	"github.com/gernest/zedlist/modules/version"
-
-	"github.com/codegangsta/cli"
-	"github.com/gernest/zedlist/cmd/app"
-)
-
-func main() {
-	zedApp := cli.NewApp()
-	zedApp.Name = "Zedlist"
-	zedApp.Usage = "A job recruitment service"
-	zedApp.Version = version.VERSION
-	zedApp.Authors = app.Authors
-	zedApp.Commands = []cli.Command{
-		app.ServerCommand,
-		app.MigrateCommand,
-	}
-	zedApp.Run(os.Args)
-}
+// Package zedlist is a job recruitment service.
+package zedlist


### PR DESCRIPTION
To avoid double rewriting of documentation, I moved the zedlist command
to cmd/zedlist. This way, the whole zedlist documentation will be done
via godoc and browsable online on the godoc.org.
